### PR TITLE
Write scripts to auto-increment MongoDB record IDs

### DIFF
--- a/server/db/mongodb/autoincrement.js
+++ b/server/db/mongodb/autoincrement.js
@@ -1,70 +1,80 @@
-// const { Product } = require('../../db/mongodb/Product');
-// const { Review } = require('../../db/mongodb/Review');
-
+const cluster = require('cluster');
 let MongoClient = require('mongodb').MongoClient;
-MongoClient.connect('mongodb://localhost:27017/amazon-cart', (err, db) => {
-    if (err) throw err;
-    console.log('Connected To DB');
-    const dbo = db.db('amazon-cart');
-    
-    // dbo.collection("reviews").find({productName: 'Generic Frozen Fish'}, function (err, docs) {
-    //     if (err) {
-    //         console.log(err);
-    //     } else {
-    //         console.log(docs);
-    //     }
-    // });
-});  
 
-/* create counters collection */ 
-db.counters.insert (
-    {
-        _id: "products",
-        // seq: 0
-        seq: NumberInt(0)
-    }
-);
 
-db.counters.insert (
-    {
-        _id: "reviews",
-        seq: NumberInt(0)
-    }
-);
+if (cluster.isMaster) {
+  // Count the machine's CPUs
+  let cpuCount = require('os').cpus().length;
 
-/* increment counter by 1 */ 
-function getNextSequence(name) {
-   var ret = db.counters.findAndModify(
-          {
-            query: { _id: name },
-            update: { $inc: { seq: 1 } },
-            new: true
-          }
-   );
- 
-   return ret.seq;
+  // Create a worker for each CPU
+  for (var i = 0; i < cpuCount; i += 1) {
+      cluster.fork();
+  }
+  // If worker dies, replace with new worker
+  cluster.on('exit', function (worker) {
+    console.log('Worker %d has died', worker.id);
+    cluster.fork();
+  });
+
+} else {
+    // TODO: Auto-increment MongoDB IDs here
+    MongoClient.connect('mongodb://localhost:27017/amazon-cart', (err, db) => {
+        if (err) throw err;
+        console.log('Connected To DB');
+        const dbo = db.db('amazon-cart');
+
+        /* create counters collection */ 
+        db.counters.insert (
+            {
+                _id: "reviews",
+                seq: NumberInt(0)
+            }
+        );
+
+        /* increment counter by 1 */ 
+        function getNextSequence(name) {
+        var ret = db.counters.findAndModify(
+            {
+                query: { _id: name },
+                update: { $inc: { seq: 1 } },
+                new: true
+            }
+        );
+        return ret.seq;
+        }
+
+        /* add incremental counters to reviews */ 
+        // TODO: Find and update only records without id field
+        db.reviews.find({}).forEach(function(doc){  
+            db.reviews.update({_id:  doc._id}, {$set: {
+                id: getNextSequence("reviews")
+            }});    
+        });
+
+    });
 }
 
-/* add incremental counters to reviews */ 
-db.reviews.find({}).forEach(function(doc){
-         
-    db.reviews.update({_id:  doc._id}, {$set: {
-        id: getNextSequence("reviews")
-    }});    
-});
 
+// db.counters.insert (
+//     {
+//         _id: "products",
+//         // seq: 0
+//         seq: NumberInt(0)
+//     }
+// );
 
-/* remove id fields from reviews */ 
+/* remove id fields from reviews 
 db.reviews.find().forEach(function(doc){
     db.reviews.update({_id :  doc._id}, {
        $unset: {id : ""}
     });    
 });
- 
-/* reset counters to zero */ 
+ */ 
+/* reset counters to zero  
 db.counters.find().forEach(function(doc){    
     db.counters.update({_id :  doc._id}, {
        // $set : {seq: 0}
        $set : {seq: NumberInt(0)}
     });    
 });
+*/

--- a/server/db/mongodb/autoincrement.js
+++ b/server/db/mongodb/autoincrement.js
@@ -16,24 +16,36 @@ if (cluster.isMaster) {
     cluster.fork();
   });
 
-} else {
-    // TODO: Auto-increment MongoDB IDs here
-    MongoClient.connect('mongodb://localhost:27017/amazon-cart', (err, db) => {
+  MongoClient.connect('mongodb://localhost:27017/amazon-cart', { useNewUrlParser: true }, (err, db) => {
         if (err) throw err;
         console.log('Connected To DB');
         const dbo = db.db('amazon-cart');
 
         /* create counters collection */ 
-        db.counters.insert (
-            {
-                _id: "reviews",
-                seq: NumberInt(0)
-            }
-        );
+        dbo.createCollection('counters', (err, res) => {
+            if (err) throw err;
+            console.log(`'counters' collection created`);
+
+            dbo.collection('counters').insertOne(
+                {
+                    _id: "reviews",
+                    seq: 0
+                }
+            );            
+        });
+        // db.close();
+  });
+
+} else {
+    // TODO: Auto-increment MongoDB IDs here
+    MongoClient.connect('mongodb://localhost:27017/amazon-cart', { useNewUrlParser: true }, (err, db) => {
+        if (err) throw err;
+        console.log('Connected To DB');
+        const dbo = db.db('amazon-cart');
 
         /* increment counter by 1 */ 
         function getNextSequence(name) {
-        var ret = db.counters.findAndModify(
+        var ret = dbo.counters.findAndModify(
             {
                 query: { _id: name },
                 update: { $inc: { seq: 1 } },
@@ -45,12 +57,15 @@ if (cluster.isMaster) {
 
         /* add incremental counters to reviews */ 
         // TODO: Find and update only records without id field
-        db.reviews.find({}).forEach(function(doc){  
-            db.reviews.update({_id:  doc._id}, {$set: {
-                id: getNextSequence("reviews")
-            }});    
-        });
+        // Limit search to range of numbers (ex. 1-10,000)
+        // dbo.reviews.find({}).forEach(function(doc){  
+        //     dbo.reviews.update({_id:  doc._id}, {$set: {
+        //         id: getNextSequence("reviews")
+        //     }});    
+        // });
 
+        console.log('moo');
+        
     });
 }
 

--- a/server/db/mongodb/autoincrement.js
+++ b/server/db/mongodb/autoincrement.js
@@ -32,12 +32,11 @@ if (cluster.isMaster) {
                     seq: 0
                 }
             );            
+            db.close();
         });
-        // db.close();
   });
 
 } else {
-    // TODO: Auto-increment MongoDB IDs here
     MongoClient.connect('mongodb://localhost:27017/amazon-cart', { useNewUrlParser: true }, (err, db) => {
         if (err) throw err;
         console.log('Connected To DB');
@@ -45,7 +44,7 @@ if (cluster.isMaster) {
 
         /* increment counter by 1 */ 
         function getNextSequence(name) {
-        var ret = dbo.counters.findAndModify(
+        let ret = dbo.collection('counters').findAndModify(
             {
                 query: { _id: name },
                 update: { $inc: { seq: 1 } },
@@ -58,14 +57,18 @@ if (cluster.isMaster) {
         /* add incremental counters to reviews */ 
         // TODO: Find and update only records without id field
         // Limit search to range of numbers (ex. 1-10,000)
-        // dbo.reviews.find({}).forEach(function(doc){  
-        //     dbo.reviews.update({_id:  doc._id}, {$set: {
-        //         id: getNextSequence("reviews")
-        //     }});    
-        // });
 
-        console.log('moo');
-        
+        // find records where value of stars is not greater than 0
+        // limit results to 3 records
+        // dbo.collection('reviews').find({stars: {$not: {$gt: 0}}}).limit(3).forEach(function(doc){  
+
+        dbo.collection('reviews').find({id: {$not: {$gt: 0}}}).limit(3).forEach(function(doc){  
+            // dbo.reviews.update({_id:  doc._id}, {$set: {
+            //     id: getNextSequence("reviews")
+            // }});    
+            console.log(doc);
+            
+        });
     });
 }
 

--- a/server/db/mongodb/autoincrement.js
+++ b/server/db/mongodb/autoincrement.js
@@ -1,0 +1,70 @@
+// const { Product } = require('../../db/mongodb/Product');
+// const { Review } = require('../../db/mongodb/Review');
+
+let MongoClient = require('mongodb').MongoClient;
+MongoClient.connect('mongodb://localhost:27017/amazon-cart', (err, db) => {
+    if (err) throw err;
+    console.log('Connected To DB');
+    const dbo = db.db('amazon-cart');
+    
+    // dbo.collection("reviews").find({productName: 'Generic Frozen Fish'}, function (err, docs) {
+    //     if (err) {
+    //         console.log(err);
+    //     } else {
+    //         console.log(docs);
+    //     }
+    // });
+});  
+
+/* create counters collection */ 
+db.counters.insert (
+    {
+        _id: "products",
+        // seq: 0
+        seq: NumberInt(0)
+    }
+);
+
+db.counters.insert (
+    {
+        _id: "reviews",
+        seq: NumberInt(0)
+    }
+);
+
+/* increment counter by 1 */ 
+function getNextSequence(name) {
+   var ret = db.counters.findAndModify(
+          {
+            query: { _id: name },
+            update: { $inc: { seq: 1 } },
+            new: true
+          }
+   );
+ 
+   return ret.seq;
+}
+
+/* add incremental counters to reviews */ 
+db.reviews.find({}).forEach(function(doc){
+         
+    db.reviews.update({_id:  doc._id}, {$set: {
+        id: getNextSequence("reviews")
+    }});    
+});
+
+
+/* remove id fields from reviews */ 
+db.reviews.find().forEach(function(doc){
+    db.reviews.update({_id :  doc._id}, {
+       $unset: {id : ""}
+    });    
+});
+ 
+/* reset counters to zero */ 
+db.counters.find().forEach(function(doc){    
+    db.counters.update({_id :  doc._id}, {
+       // $set : {seq: 0}
+       $set : {seq: NumberInt(0)}
+    });    
+});


### PR DESCRIPTION
Add "id" fields to DB records. This allows client to fetch data from the API by a product's ID number instead of its MongoDB ObjectID. By referencing the ID number, the add-to-cart component can be integrated with Team Leo's other components.